### PR TITLE
Saliency + delta 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__
 *~
 *.swp
 *.swo
+
+# Igor
+igor.sh


### PR DESCRIPTION
The changes do not affect the default behaviour.
Three new flags:
--saliency_method={"spectral_residual", "vgg"} (default: OpenCV's Spectral Residual method)
--multilevel_saliency (store true) -- express delta as a function of saliency map and increase the contribution of saliency map at lower levels of WCT.
--mls_reverse (store true) -- decrease the contribution of saliency map at lower levels. 